### PR TITLE
Unicode character support and string cast

### DIFF
--- a/plex_collections.py
+++ b/plex_collections.py
@@ -26,8 +26,8 @@ sheet = client.open(GSPREAD_NAME).sheet1
 sheet = sheet.get_all_records()
 
 def record_missing():
-  f= open("missing.txt","a+")
-  f.write(row['Movies'] + '\n')
+  f= open("missing.txt","a+", encoding='utf8')
+  f.write(str(row['Movies']) + '\n')
   f.close
 
 # open and clear a file to record missing movies


### PR DESCRIPTION
I was having some problems with movies that had unicode characters such as "⅓". They were stopping the script dead in its tracks. I'm not the best at python but adding utf8 encoding seemed to fix the problems I was having. 

Also movies that were only numbers, such as "300" were failing to be written to the file. So I cast everything to a string before it was written.